### PR TITLE
[BUGFIX] Add missing comma on condition

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -61,7 +61,12 @@
 		],
 		"lint:composer": "@composer normalize --dry-run",
 		"lint:editorconfig": "ec",
+{%if not features.rector and not features.phpstan %}
 		"lint:php": "php-cs-fixer fix --dry-run"
+{% else %}
+		"lint:php": "php-cs-fixer fix --dry-run",
+{% endif %}
+
 {% if features.rector %}
 		"migration": [
 			"@migration:rector"

--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -80,7 +80,7 @@
 		"sca": [
 			"@sca:php"
 		],
-		"sca:php": "phpstan analyse -c phpstan.neon --memory-limit=2G $(find packages -mindepth 2 -maxdepth 2 -type d -name 'Classes' -o -name 'Configuration' -o -name 'Tests')",
+		"sca:php": "phpstan analyse -c phpstan.neon --memory-limit=2G",
 {% endif %}
 		"test": [
 			"@test:unit"


### PR DESCRIPTION
This PR fixes a `composer.json` syntax when both PHPStand and Rector are selected. Furthermore, the PHPStan composer script wasn't generic enough for this basic template.