### PR TITLE
[DOCS] Correct link to offical project-builder documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ of Composer based PHP projects.
 
 
 
-> 💡 Please refer to the official Project Builder [documentation](https://github.com/CPS-IT/project-builder/blob/main/docs/usage.md)
+> 💡 Please refer to the official Project Builder [documentation](https://project-builder.cps-it.de)
 > to learn about alternative ways to create your project.
 
 ## 👩‍💻:🧑‍💻 Contribution


### PR DESCRIPTION
The official documentation of `cpsit/project-builder` was recently moved to an external URL. Thus, the linked file does no longer exist. It is now replaced by a link to the new documentation URL.