### PR TITLE
[BUGFIX]  Remove unnecessary twig filter

### DIFF
--- a/templates/src/.github/workflows/cgl.yaml.twig
+++ b/templates/src/.github/workflows/cgl.yaml.twig
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: {{ packages.php|replace({'.': ''}) }}
+          php-version: {{ packages.php }}
           tools: composer:v2, composer-unused
           coverage: none
 

--- a/templates/src/rector.php.twig
+++ b/templates/src/rector.php.twig
@@ -8,7 +8,7 @@ use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_{{ packages.php|replace({'.': ''}) }},
+        LevelSetList::UP_TO_PHP_{{ packages.php }},
     ]);
 
     // Disable parallel otherwise non php file processing is not working


### PR DESCRIPTION
Fixed two instances of a obsolete twig filter. Thanks @eliashaeussler for spotting this! 💛 

```diff
-php-version: {{ packages.php|replace({'.': ''}) }}
+php-version: {{ packages.php }}
```