### PR TITLE
[DOCS] Fix contribution instructions to clone repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ all steps below.
 
 ```bash
 # Clone repository
-git clone https://github.com/mteu/project-builder-template.git
-cd project-builder-template
+git clone https://github.com/mteu/basic-project-template.git
+cd basic-project-template
 
 # Install dependencies
 composer install


### PR DESCRIPTION
The instructions to clone this repository within `CONTRIBUTING.md` were outdated. I've updated them according to the new repository name.