### PR TITLE
[FEATURE] Execute shell commands after build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"cpsit/project-builder": "^2.3"
+		"cpsit/project-builder": "dev-develop as 2.3"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"cpsit/project-builder": "^2.2"
+		"cpsit/project-builder": "^2.3"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa1e002b229120201f7dfb53825bd058",
+    "content-hash": "b4f7ab1b9f7cc88da5fb96948499c2c1",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -82,16 +82,16 @@
         },
         {
             "name": "cpsit/project-builder",
-            "version": "2.2.4",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CPS-IT/project-builder.git",
-                "reference": "ad7d646be95e9e0a8f41977a3182e1f4e0d4bb84"
+                "reference": "c71f82e46d3597c8a84a654040a595fb9c4c6bec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CPS-IT/project-builder/zipball/ad7d646be95e9e0a8f41977a3182e1f4e0d4bb84",
-                "reference": "ad7d646be95e9e0a8f41977a3182e1f4e0d4bb84",
+                "url": "https://api.github.com/repos/CPS-IT/project-builder/zipball/c71f82e46d3597c8a84a654040a595fb9c4c6bec",
+                "reference": "c71f82e46d3597c8a84a654040a595fb9c4c6bec",
                 "shasum": ""
             },
             "require": {
@@ -116,6 +116,7 @@
                 "symfony/expression-language": "^5.4 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0",
                 "symfony/finder": "^5.4 || ^6.0",
+                "symfony/process": "^5.4 || ^6.0",
                 "symfony/yaml": "^5.4 || ^6.0",
                 "twig/twig": "^3.3.3",
                 "webmozart/assert": "^1.11"
@@ -167,9 +168,9 @@
             "description": "Composer package to create new projects from project templates",
             "support": {
                 "issues": "https://github.com/CPS-IT/project-builder/issues",
-                "source": "https://github.com/CPS-IT/project-builder/tree/2.2.4"
+                "source": "https://github.com/CPS-IT/project-builder/tree/develop"
             },
-            "time": "2023-06-28T18:35:39+00:00"
+            "time": "2023-07-07T12:58:38+00:00"
         },
         {
             "name": "cuyz/valinor",
@@ -2515,6 +2516,67 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
+            "name": "symfony/process",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "8741e3ed7fe2e91ec099e02446fb86667a0f1628"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8741e3ed7fe2e91ec099e02446fb86667a0f1628",
+                "reference": "8741e3ed7fe2e91ec099e02446fb86667a0f1628",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v6.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-19T08:06:44+00:00"
+        },
+        {
             "name": "symfony/service-contracts",
             "version": "v3.3.0",
             "source": {
@@ -3890,9 +3952,18 @@
             "time": "2022-11-03T14:55:06+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "cpsit/project-builder",
+            "version": "dev-develop",
+            "alias": "2.3",
+            "alias_normalized": "2.3.0.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "cpsit/project-builder": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/config.yaml
+++ b/config.yaml
@@ -29,10 +29,10 @@ steps:
   - type: mirrorProcessedFiles
   - type: runCommand
     options:
-      command: "echo 'Hello World!'"
+      command: "touch DONT_TOUCH_THIS"
   - type: runCommand
     options:
-      command: "echo 'Second command'"
+      command: "composer install"
 
 properties:
   # Project

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,12 @@ steps:
   - type: runCommand
     options:
       command: "composer install"
+  - type: runCommand
+    options:
+      command: "git init --initial-branch=main"
+  - type: runCommand
+    options:
+      command: "git commit add . && git commit -am 'Initial commit'"
 
 properties:
   # Project

--- a/config.yaml
+++ b/config.yaml
@@ -29,13 +29,14 @@ steps:
   - type: mirrorProcessedFiles
   - type: runCommand
     options:
+      command: "composer normalize"
+      skipConfirmation: true
+  - type: runCommand
+    options:
       command: "composer install"
   - type: runCommand
     options:
       command: "git init --initial-branch=main"
-  - type: runCommand
-    options:
-      command: "git commit add . && git commit -am 'Initial commit'"
 
 properties:
   # Project

--- a/config.yaml
+++ b/config.yaml
@@ -29,10 +29,7 @@ steps:
   - type: mirrorProcessedFiles
   - type: runCommand
     options:
-      command: "touch DONT_TOUCH_THIS"
-  - type: runCommand
-    options:
-      command: "composer install"
+      command: "composer normalize && composer install"
 
 properties:
   # Project

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,12 @@ steps:
 
   - type: generateBuildArtifact
   - type: mirrorProcessedFiles
+  - type: runCommand
+    options:
+      command: "echo 'Hello World!'"
+  - type: runCommand
+    options:
+      command: "echo 'Second command'"
 
 properties:
   # Project


### PR DESCRIPTION
With version 2.3 of the Project Builder it will be possible to run custom shell commands in the working and/or target directory. This PR add three commands, that are most likely to be helpful post build.

```yaml
- type: runCommand
    options:
      command: "composer normalize"
      skipConfirmation: true
- type: runCommand
    options:
      command: "composer install"
- type: runCommand
    options:
      command: "git init --initial-branch=main"
```