### PR TITLE
[BUGFIX] Fix invalid json when working with conditions

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -34,11 +34,9 @@
 	"config": {
 		"allow-plugins": {
 {% if features.phpstan %}
-			"ergebnis/composer-normalize": true,
-			"phpstan/extension-installer": true
-{% else %}
-			"ergebnis/composer-normalize": true
+			"phpstan/extension-installer": true,
 {% endif %}
+			"ergebnis/composer-normalize": true
 		},
 		"platform": {
 			"php": "{{ get_latest_stable_php_version(packages.php) }}"
@@ -54,19 +52,6 @@
 		"fix:composer": "@composer normalize",
 		"fix:editorconfig": "ec --fix",
 		"fix:php": "php-cs-fixer fix",
-		"lint": [
-			"@lint:composer",
-			"@lint:editorconfig",
-			"@lint:php"
-		],
-		"lint:composer": "@composer normalize --dry-run",
-		"lint:editorconfig": "ec",
-{%if not features.rector and not features.phpstan %}
-		"lint:php": "php-cs-fixer fix --dry-run"
-{% else %}
-		"lint:php": "php-cs-fixer fix --dry-run",
-{% endif %}
-
 {% if features.rector %}
 		"migration": [
 			"@migration:rector"
@@ -82,20 +67,20 @@
 		],
 		"sca:php": "phpstan analyse -c phpstan.neon --memory-limit=2G",
 {% endif %}
-		"test": [
-			"@test:unit"
+		"lint": [
+			"@lint:composer",
+			"@lint:editorconfig",
+			"@lint:php"
 		],
-		"test:unit": "phpunit -c phpunit.xml"
+		"lint:composer": "@composer normalize --dry-run",
+		"lint:editorconfig": "ec",
+		"lint:php": "php-cs-fixer fix --dry-run"
 	},
 	"scripts-descriptions": {
 		"fix": "Fix all code quality issues reported by the registered linters",
 		"fix:composer": "Fix all issues in `composer.json`",
 		"fix:editorconfig": "Fix all styling issues violating the `.editorconfig` rules",
 		"fix:php": "Fix all styling issues violating the configured PHP-CS-Fixer rules",
-		"lint": "Run all registered linters to detect code quality issues",
-		"lint:composer": "Lint `composer.json` to detect unnormalized styles",
-		"lint:editorconfig": "Lint all project files to detect violations of the `.editorconfig` rules",
-		"lint:php": "Lint all PHP files to detect coding style violations",
 {% if features.rector %}
 		"migration": "Run all registered automatic code migrations",
 		"migration:rector": "Perform automatic code migration with TYPO3 Rector, based on the registered rules",
@@ -104,7 +89,9 @@
 		"sca": "Run all registered static code analyzers to detect issues in the codebase",
 		"sca:php": "Analyze all PHP files by using PHPStan, based on the configured level",
 {% endif %}
-		"test": "Run all configured test suites",
-		"test:unit": "Run unit tests for all local packages"
+		"lint": "Run all registered linters to detect code quality issues",
+		"lint:composer": "Lint `composer.json` to detect un-normalized styles",
+		"lint:editorconfig": "Lint all project files to detect violations of the `.editorconfig` rules",
+		"lint:php": "Lint all PHP files to detect coding style violations"
 	}
 }


### PR DESCRIPTION
Loading conditional features into the `composer.json` is still not ideal since we need to avoid excessive commas. This PR fixes the invalid syntax by adding compulsory requirements and scripts at the end well recognizing that is not ordered alphabetically. One needs to `composer normalize` at the end. 