### PR TITLE
[BUGFIX] Validate Composer package name against regex pattern

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,9 @@ properties:
         defaultValue: "{{ project.vendor|slugify }}/{{ project.name|slugify }}"
         validators:
           - type: notEmpty
+          - type: regex
+            options:
+              pattern: '/^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$/'
       - identifier: url
         name: Website URL
         type: staticValue


### PR DESCRIPTION
The PR fixes a potential invalid `composer.json` by validating the Composer package name against the pattern given in the https://getcomposer.org/schema.json.

<img width="376" alt="image" src="https://github.com/mteu/basic-project-template/assets/2636487/a9b1d009-79b4-43b6-a0d2-e88817b24d6d">
