### PR TITLE
[FEATURE] Offer a Github default value for the project url

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,7 @@ properties:
       - identifier: url
         name: Website URL
         type: staticValue
+        defaultValue: "https://github.com/{{ project.vendor|slugify }}/{{ project.name|slugify }}"
         validators:
           - type: notEmpty
           - type: url


### PR DESCRIPTION
Let's be honest here. I'm basically the only one using this template and the majority of project land on GitHub. So why not save a few seconds each time. 🤷 