### PR TITLE
[BUGFIX] Run `composer update` after project generation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ steps:
   - type: mirrorProcessedFiles
   - type: runCommand
     options:
-      command: "composer install && composer normalize"
+      command: "composer update && composer normalize"
       skipConfirmation: true
   - type: runCommand
     options:


### PR DESCRIPTION
This PR changes the fifth project generation step to run `composer update` instead of `composer install`.

> [!NOTE]
>
> If no `composer.lock` file exists next to `composer.json`, running `composer install` automatically runs `composer update` instead, but with an additional notice:
> 
> ![image](https://github.com/mteu/basic-project-template/assets/16313625/db48878e-1ea9-4fc5-a183-c8728c77ba04)
> 
> Therefore, it is save to explicitly switch to `composer update` instead.